### PR TITLE
FIX: remove trigger path in CI build

### DIFF
--- a/build/build-solution.yml
+++ b/build/build-solution.yml
@@ -14,24 +14,36 @@ steps:
       echo "##vso[task.logissue type=error;]Missing template parameter \"versionSuffix\""
       echo "##vso[task.complete result=Failed;]"
     fi
+    if [ -z "$VERSION" ]; then
+      echo "##vso[task.logissue type=error;]Missing template parameter \"version\""
+      echo "##vso[task.complete result=Failed;]"
+    fi
     if [ -z "$PROJECTS" ]; then
       echo "##vso[task.logissue type=error;]Missing template parameter \"projects\""
       echo "##vso[task.complete result=Failed;]"
     fi
+
+    if [ $VERSION_SUFFIX == '' ]; then
+      $VERSION_SUFFIX_COMMAND = ''
+      echo "##vso[task.setvariable variable=versionSuffixCommand]$VERSION_SUFFIX_COMMAND"
+    else
+      $VERSION_SUFFIX_COMMAND = '--version-suffix $VERSION_SUFFIX'
+      echo "##vso[task.setvariable variable=versionSuffixCommand]$VERSION_SUFFIX_COMMAND"
+    fi
+    
+    if [ $VERSION == '' ]; then
+      $VERSION_COMMAND = ''
+      echo "##vso[task.setvariable variable=versionCommand]$VERSION_COMMAND"
+    else
+      $VERSION_COMMAND = '/property:Version=$VERSION'
+      echo "##vso[task.setvariable variable=versionCommand]$VERSION_COMMAND"
+    fi
   env:
     DOTNET_SDK_VERSION: ${{ parameters.dotnetSdkVersion }}
     VERSION_SUFFIX: ${{ parameters.versionSuffix }}
+    VERSION: ${{ parameters.version }}
     PROJECTS: ${{ parameters.projects }}
   displayName: Check for required parameters in YAML template
-- powershell: |
-    $versionCommand = '';
-    if ('${{ parameters.version }}' -ne '') {
-      $versionCommand = '/property:Version=${{ parameters.version }}';
-    }
-    $versionSuffixCommand = '';
-    if ('${{ parameters.versionSuffix }}' -ne '') {
-      $versionSuffixCommand = '--version-suffix ${{ parameters.versionSuffix }}'
-    }
 - task: DotNetCoreInstaller@0
   displayName: 'Import .NET Core SDK (${{ parameters.dotnetSdkVersion }})'
   inputs:

--- a/build/build-solution.yml
+++ b/build/build-solution.yml
@@ -22,28 +22,28 @@ steps:
       echo "##vso[task.logissue type=error;]Missing template parameter \"projects\""
       echo "##vso[task.complete result=Failed;]"
     fi
-
-    if [ $VERSION_SUFFIX == '' ]; then
-      $VERSION_SUFFIX_COMMAND = ''
-      echo "##vso[task.setvariable variable=versionSuffixCommand]$VERSION_SUFFIX_COMMAND"
-    else
-      $VERSION_SUFFIX_COMMAND = '--version-suffix $VERSION_SUFFIX'
-      echo "##vso[task.setvariable variable=versionSuffixCommand]$VERSION_SUFFIX_COMMAND"
-    fi
-    
-    if [ $VERSION == '' ]; then
-      $VERSION_COMMAND = ''
-      echo "##vso[task.setvariable variable=versionCommand]$VERSION_COMMAND"
-    else
-      $VERSION_COMMAND = '/property:Version=$VERSION'
-      echo "##vso[task.setvariable variable=versionCommand]$VERSION_COMMAND"
-    fi
   env:
     DOTNET_SDK_VERSION: ${{ parameters.dotnetSdkVersion }}
     VERSION_SUFFIX: ${{ parameters.versionSuffix }}
     VERSION: ${{ parameters.version }}
     PROJECTS: ${{ parameters.projects }}
   displayName: Check for required parameters in YAML template
+- powershell: |	
+    $versionCommand = '';	
+    if ('${{ parameters.version }}' -ne '') {	
+      $versionCommand = '/property:Version=${{ parameters.version }}';	
+    }	
+    $versionSuffixCommand = '';	
+    if ('${{ parameters.versionSuffix }}' -ne '') {	
+      $versionSuffixCommand = '--version-suffix ${{ parameters.versionSuffix }}'	
+    }
+
+    Write-Host "Version command = $versionCommand"
+    Write-Host "##vso[task.setvariable variable=versionCommand]$versionCommand"
+
+    Write-Host "Version suffix command = $versionSuffixCommand"
+    Write-Host "##vso[task.setvariable variable=versionSuffixCommand]$versionSuffixCommand"
+  displayName: 'Determine version/version-suffix commands'
 - task: DotNetCoreInstaller@0
   displayName: 'Import .NET Core SDK (${{ parameters.dotnetSdkVersion }})'
   inputs:

--- a/build/build-solution.yml
+++ b/build/build-solution.yml
@@ -3,6 +3,8 @@ parameters:
   versionSuffix: ''
   version: ''
   projects: 'src/*.sln'
+  versionCommand: ''
+  versionSuffixCommand: ''
 
 steps:
 - bash: |

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -4,9 +4,6 @@ trigger:
   branches:
     include:
       - master
-  paths:
-    include:
-      - src/*
 
 pr:
   paths:


### PR DESCRIPTION
Since the CI build verifies the YAML builds; we should trigger on changes in the YAML builds.

I removed all trigger paths entirely to be safe.