### PR TITLE
Remove @templates to use version in repo, not master

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -57,7 +57,7 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: ./../test/run-unit-tests.yml
+          - template: ./../../test/run-unit-tests.yml
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
               projectName: '$(Project).Tests.Unit'
@@ -77,7 +77,7 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: ./../test/run-integration-tests.yml
+          - template: ./../../test/run-integration-tests.yml
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
               projectName: '$(Project).Tests.Integration'
@@ -100,4 +100,4 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: ./../nuget/publish-preview-package.yml
+          - template: ./../../nuget/publish-preview-package.yml

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -5,13 +5,6 @@ trigger:
     include:
       - master
 
-resources:
-  repositories:
-    - repository: templates
-      type: github
-      name: arcus-azure/azure-devops-templates
-      endpoint: arcus-azure
-
 variables:
   - group: 'Build Configuration'
   # Always use fixed version for .NET Core SDK
@@ -30,10 +23,10 @@ stages:
         pool:
           vmImage: 'ubuntu-16.04'
         steps:
-          - template: 'nuget/determine-pr-version.yml@templates'
+          - template: 'nuget/determine-pr-version.yml'
             parameters:
               manualTriggerVersion: $(Package.Version.ManualTrigger)
-          - template: 'build/build-solution.yml@templates'
+          - template: 'build/build-solution.yml'
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
               versionSuffix: '-preview-1'
@@ -64,7 +57,7 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: test/run-unit-tests.yml@templates
+          - template: test/run-unit-tests.yml
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
               projectName: '$(Project).Tests.Unit'
@@ -84,7 +77,7 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: test/run-integration-tests.yml@templates
+          - template: test/run-integration-tests.yml
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
               projectName: '$(Project).Tests.Integration'
@@ -107,4 +100,4 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: nuget/publish-preview-package.yml@templates
+          - template: nuget/publish-preview-package.yml

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -26,7 +26,7 @@ stages:
           - template: ./../../nuget/determine-pr-version.yml
             parameters:
               manualTriggerVersion: $(Package.Version.ManualTrigger)
-          - template: ./../build/build-solution.yml
+          - template: ./../../build/build-solution.yml
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
               versionSuffix: '-preview-1'

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -23,7 +23,7 @@ stages:
         pool:
           vmImage: 'ubuntu-16.04'
         steps:
-          - template: ./../nuget/determine-pr-version.yml
+          - template: ./../../nuget/determine-pr-version.yml
             parameters:
               manualTriggerVersion: $(Package.Version.ManualTrigger)
           - template: build/build-solution.yml

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -26,7 +26,7 @@ stages:
           - template: ./../../nuget/determine-pr-version.yml
             parameters:
               manualTriggerVersion: $(Package.Version.ManualTrigger)
-          - template: build/build-solution.yml
+          - template: ./../build/build-solution.yml
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
               versionSuffix: '-preview-1'

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -23,7 +23,7 @@ stages:
         pool:
           vmImage: 'ubuntu-16.04'
         steps:
-          - template: ./nuget/determine-pr-version.yml
+          - template: ./../nuget/determine-pr-version.yml
             parameters:
               manualTriggerVersion: $(Package.Version.ManualTrigger)
           - template: build/build-solution.yml
@@ -57,7 +57,7 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: ./test/run-unit-tests.yml
+          - template: ./../test/run-unit-tests.yml
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
               projectName: '$(Project).Tests.Unit'
@@ -77,7 +77,7 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: ./test/run-integration-tests.yml
+          - template: ./../test/run-integration-tests.yml
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
               projectName: '$(Project).Tests.Integration'
@@ -100,4 +100,4 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: ./nuget/publish-preview-package.yml
+          - template: ./../nuget/publish-preview-package.yml

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -23,10 +23,10 @@ stages:
         pool:
           vmImage: 'ubuntu-16.04'
         steps:
-          - template: 'nuget/determine-pr-version.yml'
+          - template: ./nuget/determine-pr-version.yml
             parameters:
               manualTriggerVersion: $(Package.Version.ManualTrigger)
-          - template: 'build/build-solution.yml'
+          - template: build/build-solution.yml
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
               versionSuffix: '-preview-1'
@@ -57,7 +57,7 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: test/run-unit-tests.yml
+          - template: ./test/run-unit-tests.yml
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
               projectName: '$(Project).Tests.Unit'
@@ -77,7 +77,7 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: test/run-integration-tests.yml
+          - template: ./test/run-integration-tests.yml
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
               projectName: '$(Project).Tests.Integration'
@@ -100,4 +100,4 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: nuget/publish-preview-package.yml
+          - template: ./nuget/publish-preview-package.yml


### PR DESCRIPTION
Remove `@templates` for every template usage so that we use version in repo, not from master branch.

This was the case since we were using `resources.repositories`