### PR TITLE
CHORE: copy CI build to '.azure-devops' folder

### DIFF
--- a/.azure-devops/ci-build.yml
+++ b/.azure-devops/ci-build.yml
@@ -1,0 +1,103 @@
+name: $(date:yyyyMMdd)$(rev:.r)
+
+trigger:
+  branches:
+    include:
+      - master
+
+variables:
+  - group: 'Build Configuration'
+  # Always use fixed version for .NET Core SDK
+  - name: 'DotNet.Sdk.Version'
+    value: '2.2.105'
+  - name: 'Project'
+    value: 'Arcus.DevOps.Templates'
+  - name: 'Arcus_DevOps_Templates_TestValue'
+    value: 'Replace token with me!'
+  # 'Package.Version.ManualTrigger' is added as queue-time variable on build in Azure DevOps
+
+stages:
+  - stage: Build
+    jobs:
+      - job: Compile
+        pool:
+          vmImage: 'ubuntu-16.04'
+        steps:
+          - template: ./../../nuget/determine-pr-version.yml
+            parameters:
+              manualTriggerVersion: $(Package.Version.ManualTrigger)
+          - template: ./../../build/build-solution.yml
+            parameters:
+              dotnetSdkVersion: '$(DotNet.Sdk.Version)'
+              versionSuffix: '-preview-1'
+              version: '1.2.3'
+          - task: CopyFiles@2
+            displayName: 'Copy build artifacts'
+            inputs:
+              contents: '**/?(bin|obj)/**'
+              targetFolder: '$(Pipeline.Workspace)/build'
+          - task: PublishPipelineArtifact@0
+            displayName: 'Publish build artifacts'
+            inputs:
+              targetPath: '$(Pipeline.Workspace)/build'
+              artifactName: Build
+
+  - stage: UnitTests
+    displayName: Unit Tests
+    dependsOn: Build
+    condition: succeeded()
+    jobs:
+      - job: UnitTests
+        displayName: 'Run unit tests'
+        pool:
+          vmImage: 'ubuntu-16.04'
+        steps:
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download build artifacts'
+            inputs:
+              artifact: 'Build'
+              path: '$(Build.SourcesDirectory)'
+          - template: ./../../test/run-unit-tests.yml
+            parameters:
+              dotnetSdkVersion: '$(DotNet.Sdk.Version)'
+              projectName: '$(Project).Tests.Unit'
+
+  - stage: IntegrationTests
+    displayName: Integration Tests
+    dependsOn: Build
+    condition: succeeded()
+    jobs:
+      - job: IntegrationTests
+        displayName: 'Run integration tests'
+        pool:
+          vmImage: 'ubuntu-16.04'
+        steps:
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download build artifacts'
+            inputs:
+              artifact: 'Build'
+              path: '$(Build.SourcesDirectory)'
+          - template: ./../../test/run-integration-tests.yml
+            parameters:
+              dotnetSdkVersion: '$(DotNet.Sdk.Version)'
+              projectName: '$(Project).Tests.Integration'
+              category: 'Integration'
+
+  - stage: ReleaseToMyget
+    displayName: 'Release to MyGet'
+    dependsOn:
+      - UnitTests
+      - IntegrationTests
+    condition: succeeded()
+    jobs:
+      - job: PushToMyGet
+        displayName: 'Push to MyGet'
+        pool:
+          vmImage: 'ubuntu-16.04'
+        steps:
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download build artifacts'
+            inputs:
+              artifact: 'Build'
+              path: '$(Build.SourcesDirectory)'
+          - template: ./../../nuget/publish-preview-package.yml


### PR DESCRIPTION
First copy the CI build to the `.azure-devops` folder so we can update the build definition in Azure DevOps. Then a follow-up PR can remove the `.\build\ci-build.yml` altogheter.

Relates to #21 