### PR TITLE
Use `condition` for GitHub releases

### DIFF
--- a/github/create-pre-release.yml
+++ b/github/create-pre-release.yml
@@ -40,3 +40,4 @@ steps:
     releaseNotes: '${{ parameters.releaseNotes }}'
     isPreRelease: true
     compareWith: 'lastRelease'
+  condition: contains('${{ parameters.tag }}'', '-')

--- a/github/create-release.yml
+++ b/github/create-release.yml
@@ -38,3 +38,4 @@ steps:
     title: '${{ parameters.releaseTitle }}'
     releaseNotesSource: input
     releaseNotes: '${{ parameters.releaseNotes }}'
+  condition: not(contains('${{ parameters.tag }}'', '-'))


### PR DESCRIPTION
Use `condition` for GitHub releases to avoid creating wrong releases, based on tags.