### PR TITLE
FIX: switch 'DotNetInstaller' > 'UseDotNet'

### DIFF
--- a/build/build-solution.yml
+++ b/build/build-solution.yml
@@ -39,9 +39,10 @@ steps:
     Write-Host "##vso[task.setvariable variable=versionCommand]$versionCommand"
     Write-Host "##vso[task.setvariable variable=versionSuffixCommand]$versionSuffixCommand"
   displayName: 'Determine version/version-suffix commands'
-- task: DotNetCoreInstaller@0
+- task: UseDotNet@2
   displayName: 'Import .NET Core SDK (${{ parameters.dotnetSdkVersion }})'
   inputs:
+    packageType: 'sdk'
     version: '${{ parameters.dotnetSdkVersion }}'
 - task: DotNetCoreCLI@2
   displayName: 'Compile'

--- a/test/run-integration-tests.yml
+++ b/test/run-integration-tests.yml
@@ -26,9 +26,10 @@ steps:
 
     Write-Host "##vso[task.setvariable variable=categoryCommand]$categoryCommand"
   displayName: 'Determine filter category command'
-- task: DotNetCoreInstaller@0
+- task: UseDotNet@2
   displayName: 'Import .NET Core SDK (${{ parameters.dotnetSdkVersion }})'
   inputs:
+    packageType: 'sdk'
     version: '${{ parameters.dotnetSdkVersion }}'
 - task: qetza.replacetokens.replacetokens-task.replacetokens@3
   displayName: 'Replace integration test tokens'

--- a/test/run-unit-tests.yml
+++ b/test/run-unit-tests.yml
@@ -16,9 +16,10 @@ steps:
     DOTNET_SDK_VERSION: ${{ parameters.dotnetSdkVersion }}
     PROJECTS: ${{ parameters.projectName }}
   displayName: Check for required parameters in YAML template
-- task: DotNetCoreInstaller@0
+- task: UseDotNet@2
   displayName: 'Import .NET Core SDK (${{ parameters.dotnetSdkVersion }})'
   inputs:
+    packageType: 'sdk'
     version: '${{ parameters.dotnetSdkVersion }}'
 - task: DotNetCoreCLI@2
   displayName: 'Run unit tests'


### PR DESCRIPTION
Using the `UseDotNet` task will make sure that previously installed .NET SDK's will not be overriden.
This is required if we want to build the projects against multiple target frameworks.