### PR TITLE
Fix - use correct `string` concat for release notes

### DIFF
--- a/github/create-release.yml
+++ b/github/create-release.yml
@@ -40,10 +40,9 @@ steps:
       Write-Host "##vso[task.setvariable variable=isPreRelease]false"
       Write-Host "##vso[task.setvariable variable=compareWith]lastFullRelease"
 
-      $releaseNotes = 
+      $releaseSummary = 
     @"
-    $Env:RELEASE_NOTES
-
+    
     ## What's new?
     ### Features
 
@@ -56,7 +55,8 @@ steps:
     ### Removal
     None.
     "@
-
+     
+      $releaseNotes = $Env:RELEASE_NOTES + $releaseSummary
       Write-Host "##vso[task.setvariable variable=releaseNotes]$releaseNotes"
       Write-Host "##vso[task.setvariable variable=isDraft]true"
     }


### PR DESCRIPTION
The release summary was not correctly added by default to the release notes. Let's see if this string concatenation will help.