### PR TITLE
feat: improve PR version determination

### DIFF
--- a/determine-pr-version.yml
+++ b/determine-pr-version.yml
@@ -56,7 +56,7 @@ steps:
             }
 
             $pullRequestNumber= "$(System.PullRequest.PullRequestNumber)"
-            $patch = "$(Rev:r)"
+            $patch = "$(rev:.r)"
             $packageVersion = "$currentVersion-PR-$pullRequestNumber-$patch"
         }
     } elseif ('$(Build.Reason)' -eq 'InvidualCI') { 

--- a/determine-pr-version.yml
+++ b/determine-pr-version.yml
@@ -14,9 +14,6 @@ parameters:
       - none
       - alpha
 
-variables:
-  patch: $[counter(1, 1)]
-
 steps:
 - bash: |
     if [ -z "$MANUAL_TRIGGER_VERSION" ]; then
@@ -59,6 +56,7 @@ steps:
             }
 
             $pullRequestNumber= "$(System.PullRequest.PullRequestNumber)"
+            $patch = "$(Rev:r)"
             $packageVersion = "$currentVersion-PR-$pullRequestNumber-$patch"
         }
     } elseif ('$(Build.Reason)' -eq 'InvidualCI') { 

--- a/determine-pr-version.yml
+++ b/determine-pr-version.yml
@@ -56,7 +56,7 @@ steps:
             }
 
             $pullRequestNumber= "$(System.PullRequest.PullRequestNumber)"
-            $patch = "$(rev:.r)"
+            $patch = "$(Build.BuildNumber)"
             $packageVersion = "$currentVersion-PR-$pullRequestNumber-$patch"
         }
     } elseif ('$(Build.Reason)' -eq 'InvidualCI') { 

--- a/determine-pr-version.yml
+++ b/determine-pr-version.yml
@@ -14,6 +14,9 @@ parameters:
       - none
       - alpha
 
+variables:
+  patch: $[counter(1, 1)]
+
 steps:
 - bash: |
     if [ -z "$MANUAL_TRIGGER_VERSION" ]; then
@@ -47,8 +50,16 @@ steps:
             $packageVersion = "dev$dateFormat$pullRequestString"
         } else {
             Write-Host "Using default PR format"
+            $nugetSearchUrl = "https://azuresearch-usnc.nuget.org/query?q=$(Project)&prerelease=false"
+            $response = Invoke-WebRequest $nugetSearchUrl
+            $json = ConvertFrom-Json $response.Content
+            $currentVersion = $json.data[0].version
+            if ($currentVersion -eq $null) {
+              $currentVersion = "0.1.0" 
+            }
+
             $pullRequestNumber= "$(System.PullRequest.PullRequestNumber)"
-            $packageVersion = "$dateFormat-PR-$pullRequestNumber"
+            $packageVersion = "$currentVersion-PR-$pullRequestNumber-$patch"
         }
     } elseif ('$(Build.Reason)' -eq 'InvidualCI') { 
         if ('${{ parameters.invidualCIFormat }}' -eq 'alpha') {


### PR DESCRIPTION
Use the current version of the released NuGet package ('0.1.0' in case not yet released) to determine a PR preview version during the multiple MyGet package releases.

Closes #45  