### PR TITLE
fix: use ubuntu-latest for build pipelines

### DIFF
--- a/.azure-devops/ci-build.yml
+++ b/.azure-devops/ci-build.yml
@@ -20,6 +20,8 @@ variables:
     value: $[counter(1, 1)]
   - name: 'GitHub.Release'
     value: 'v$(GitHub.Package.Version)$(patch)'
+  - name: 'Vm.Image'
+    value: 'ubuntu-latest'
   # 'Package.Version.ManualTrigger' is added as queue-time variable on build in Azure DevOps
 
 stages:
@@ -27,7 +29,7 @@ stages:
     jobs:
       - job: Compile
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - template: ./../../nuget/determine-pr-version.yml
             parameters:
@@ -55,7 +57,7 @@ stages:
       - job: UnitTests
         displayName: 'Run unit tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -75,7 +77,7 @@ stages:
       - job: IntegrationTests
         displayName: 'Run integration tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -98,7 +100,7 @@ stages:
       - job: PushToMyGet
         displayName: 'Push to MyGet'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -117,7 +119,7 @@ stages:
       - job: ReleaseToGitHub
         displayName: 'Release to GitHub'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'


### PR DESCRIPTION
Use the `ubuntu-latest` VM image for the build pipelines.

Relates to https://github.com/arcus-azure/arcus/issues/144